### PR TITLE
LRQA-66910 LRQA-66911 Data Engine updates in test properties

### DIFF
--- a/modules/apps/data-engine/test.properties
+++ b/modules/apps/data-engine/test.properties
@@ -30,5 +30,5 @@
         (portal.acceptance == true) AND \
         (\
             (testray.component.names ~ "data-engine") OR \
-            (testray.main.component.name ~ "Data Engine") OR \
+            (testray.main.component.name ~ "Data Engine")\
         )

--- a/modules/apps/data-engine/test.properties
+++ b/modules/apps/data-engine/test.properties
@@ -14,7 +14,6 @@
         apps/dynamic-data-mapping
 
     modules.includes.required.test.batch.class.names.includes[relevant]=\
-        apps/app-builder/**/*Test.java,\
         apps/company/**/CompanyLocalServiceTest.java,\
         apps/dynamic-data-lists/**/*Test.java,\
         apps/dynamic-data-mapping/**/*Test.java
@@ -32,5 +31,4 @@
         (\
             (testray.component.names ~ "data-engine") OR \
             (testray.main.component.name ~ "Data Engine") OR \
-            (testray.main.component.name ~ "Shared App Builder")\
         )

--- a/modules/apps/dynamic-data-mapping/test.properties
+++ b/modules/apps/dynamic-data-mapping/test.properties
@@ -29,8 +29,7 @@
         (\
             (testray.component.names ~ "Forms") OR \
             (testray.component.names ~ "Site Templates") OR \
-            (testray.main.component.name == "Forms") OR \
-            (testray.main.component.name == "Shared App Builder")\
+            (testray.main.component.name == "Forms")\
         )
 
     test.batch.run.property.query[functional-upgrade*-tomcat*-mysql*-jdk8][relevant]=\

--- a/test.properties
+++ b/test.properties
@@ -2492,7 +2492,6 @@
     #
 
     test.batch.class.names.includes[data-engine]=\
-        **/app-builder-rest-test/**/*Test.java,\
         **/data-engine/**/*Test.java,\
         **/dynamic-data-lists/**/*Test.java,\
         **/dynamic-data-mapping/**/*Test.java,\

--- a/test.properties
+++ b/test.properties
@@ -5781,6 +5781,7 @@
 
     testray.team.data-engine.component.names=\
         Data Engine,\
+        Dynamic Data Lists,\
         Upgrades Data Engine
 
    testray.team.developer-tools.component.names=\
@@ -5791,7 +5792,6 @@
         Tools
 
     testray.team.forms.component.names=\
-        Dynamic Data Lists,\
         Forms,\
         Polls,\
         Upgrades Forms,\


### PR DESCRIPTION
[LRQA-66910](https://issues.liferay.com/browse/LRQA-66910) - Remove App Builder tests from Data Engine suites
[LRQA-66911](https://issues.liferay.com/browse/LRQA-66911) - Move Dynamic Data Lists Testray Component to Data Engine