### PR TITLE
Data Engine CI Test Maintenance

### DIFF
--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/documentsadministration/fields/DMFieldGroups.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/documentsadministration/fields/DMFieldGroups.testcase
@@ -268,6 +268,8 @@ definition {
 	@description = "This test ensures it's possible to edit a field's property for a field inside a field group."
 	@priority = "3"
 	test EditFieldOnDuplicatedFieldGroup {
+		property portal.acceptance = "quarantine";
+
 		var dmDocumentTypeName = "DM Document Type Name";
 
 		DataEngine.addFieldNested(

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
@@ -659,7 +659,7 @@ definition {
 	@priority = "3"
 	test EditFieldOnDuplicatedFieldGroup {
 		property portal.acceptance = "quarantine";
-		
+
 		DataEngine.addField(
 			fieldFieldLabel = "Text",
 			fieldName = "Text");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/structures/FieldGroups.testcase
@@ -658,6 +658,8 @@ definition {
 	@description = "This is a test for LPS-98077. Edit a field placed in a duplicated FieldGroup"
 	@priority = "3"
 	test EditFieldOnDuplicatedFieldGroup {
+		property portal.acceptance = "quarantine";
+		
 		DataEngine.addField(
 			fieldFieldLabel = "Text",
 			fieldName = "Text");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedNestedFieldsWebContent.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedNestedFieldsWebContent.testcase
@@ -323,6 +323,8 @@ definition {
 	@description = "This test ensures translations persists for N languages and N field groups levels."
 	@priority = "5"
 	test TranslateWebContentFromStructureWithNLevelNestedFieldsAndToNLanguages {
+		property portal.upstream = "quarantine";
+
 		NavItem.gotoStructures();
 
 		WebContentStructures.addCP(structureName = "WC Structure Title");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedNestedFieldsWebContent.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedNestedFieldsWebContent.testcase
@@ -604,6 +604,8 @@ definition {
 	@description = "This test ensures Web Content translations do not modify previously translated content."
 	@priority = "5"
 	test TranslationDoesNotChangeAnother {
+		property portal.upstream = "quarantine";
+
 		NavItem.gotoStructures();
 
 		WebContentStructures.addCP(structureName = "WC Structure Title");

--- a/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedSimpleFieldsetsStructure.testcase
+++ b/modules/apps/data-engine/data-engine-test/src/testFunctional/tests/wem/translations/LocalizedSimpleFieldsetsStructure.testcase
@@ -1142,6 +1142,8 @@ definition {
 	@description = "This test ensures it's not possible to edit a fieldset inside a field group on a structure."
 	@priority = "4"
 	test VerifyNestedFieldsetEditionOnStructure {
+		property portal.upstream = "quarantine";
+
 		WebContentStructures.addCP(structureName = "WC Structure Name");
 
 		DataEngine.addField(


### PR DESCRIPTION
[LRQA-67535](https://issues.liferay.com/browse/LRQA-67535) Put EditFieldOnDuplicatedFieldGroup on quarantine
[LRQA-67534](https://issues.liferay.com/browse/LRQA-67534) Put EditFieldOnDuplicatedFieldGroup on quarantine
[LRQA-67580](https://issues.liferay.com/browse/LRQA-67580) Add TranslationDoesNotChangeAnother test to quarantine
[LRQA-67584](https://issues.liferay.com/browse/LRQA-67584) Add TranslateWebContentFromStructureWithNLevelNestedFieldsAndToNLanguages test to quarantine
[LRQA-67480](https://issues.liferay.com/browse/LRQA-67480) Put VerifyNestedFieldsetEditionOnStructure test on quarantine